### PR TITLE
Fixed copying overlap when writing to striped streams

### DIFF
--- a/Source/Threading/OverlappedStreamStriper.cs
+++ b/Source/Threading/OverlappedStreamStriper.cs
@@ -263,7 +263,8 @@ namespace SharpAESCrypt.Threading
                 if (c > (leftInChunk - overlapSize)) // Write touched overlapping area
                 {
                     int ovlStart = Math.Max(0, overlapSize - leftInChunk);
-                    int ovlCnt = Math.Min(c, overlapSize - ovlStart);
+                    int ovlEnd = overlapSize - leftInChunk + c;
+                    int ovlCnt = ovlEnd - ovlStart;
                     Array.Copy(buffer, offset - ovlCnt, m_overlap, ovlStart, ovlCnt);
                 }
 

--- a/Source/Threading/OverlappedStreamStriper.cs
+++ b/Source/Threading/OverlappedStreamStriper.cs
@@ -228,7 +228,8 @@ namespace SharpAESCrypt.Threading
                 if (c > (leftInChunk - overlapSize)) // Read touched overlapping area
                 {
                     int ovlStart = Math.Max(0, overlapSize - leftInChunk);
-                    int ovlCnt = Math.Min(c, overlapSize - ovlStart);
+                    int ovlEnd = overlapSize - leftInChunk + c;
+                    int ovlCnt = ovlEnd - ovlStart;
                     Array.Copy(buffer, offset - ovlCnt, m_overlap, ovlStart, ovlCnt);
                 }
 


### PR DESCRIPTION
This bug is causing invalid data in decrypted stream in Duplicati.
Incorrect bytes were copied when the data written to the buffer started before the overlap area and ended in the overlap area but before the end of it.