### PR TITLE
Don't compile static void Main in Library Assembly

### DIFF
--- a/Source/SharpAESCrypt.cs
+++ b/Source/SharpAESCrypt.cs
@@ -1986,6 +1986,7 @@ namespace SharpAESCrypt
 
         #endregion
 
+#if !NETSTANDARD2_0
         /// <summary>
         /// Main function, used when compiled as a standalone executable
         /// </summary>
@@ -2063,6 +2064,7 @@ namespace SharpAESCrypt
                 }
             }
         }
+#endif
     }
 
 }

--- a/Source/SharpAESCrypt.csproj
+++ b/Source/SharpAESCrypt.csproj
@@ -1,18 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.3.3</Version>
-    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netstandard2.0;net46;netcoreapp2.0</TargetFrameworks>
+    <Version>1.3.4</Version>
     <Copyright>LGPL 2018</Copyright>
     <Product>SharpAESCrypt</Product>
     <Company>SharpAESCrypt</Company>
     <PackageId>SharpAESCrypt</PackageId>
-    <ReleaseVersion>1.3.3</ReleaseVersion>
+    <ReleaseVersion>1.3.4</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\$(TargetFramework)\SharpAESCrypt.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <OutputType>Library</OutputType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'!='netstandard2.0'">
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
When trying to use sharpaescrypt with Xamarin, my project can not be published anymore after adding the library:

    MSB4018: Unerwarteter Fehler bei der LinkAssemblies-Aufgabe.
    System.ArgumentException: Member 'System.Void Main(System.String[])' is declared in another module and needs to be imported
       bei Mono.Cecil.MetadataBuilder.LookupToken(IMetadataTokenProvider provider)
       bei Mono.Cecil.MetadataBuilder.BuildModule()
       bei Mono.Cecil.MetadataBuilder.BuildMetadata()
       bei Mono.Cecil.ModuleWriter.<>c.<BuildMetadata>b__5_0(MetadataBuilder builder, MetadataReader _)
       bei Mono.Cecil.ModuleDefinition.Read[TItem,TRet](TItem item, Func`3 read)
       bei Mono.Cecil.ModuleWriter.BuildMetadata(ModuleDefinition module, MetadataBuilder metadata)
       bei Mono.Cecil.ModuleWriter.Write(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
       bei Mono.Cecil.ModuleWriter.WriteModule(ModuleDefinition module, Disposable`1 stream, WriterParameters parameters)
       bei Mono.Cecil.ModuleDefinition.Write(String fileName, WriterParameters parameters)
       bei Mono.Cecil.AssemblyDefinition.Write(String fileName, WriterParameters parameters)
       bei Mono.Linker.Steps.OutputStep.WriteAssembly(AssemblyDefinition assembly, String directory, WriterParameters writerParameters)
       bei Mono.Linker.Steps.OutputStep.OutputAssembly(AssemblyDefinition assembly)
       bei Mono.Linker.Steps.OutputStep.ProcessAssembly(AssemblyDefinition assembly)
       bei Mono.Linker.Steps.BaseStep.Process(LinkContext context)
       bei Mono.Linker.Pipeline.ProcessStep(LinkContext context, IStep step)
       bei Mono.Linker.Pipeline.Process(LinkContext context)
       bei MonoDroid.Tuner.Linker.Process(LinkerOptions options, ILogger logger, LinkContext& context)
       bei Xamarin.Android.Tasks.LinkAssemblies.Execute(DirectoryAssemblyResolver res)
       bei Xamarin.Android.Tasks.LinkAssemblies.Execute()
       bei Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute()
       bei Microsoft.Build.BackEnd.TaskBuilder.<ExecuteInstantiatedTask>d__26.MoveNext()

As the entry point/`Main` method is not needed when this project is used as a library,  it seems to me both consequent and an easy solution to just exclude it from the library. I could imagine that the existance of this entrypoint leads to more problems in different situations too.

Additionally, using .netstandard assemblies directly as executables seems to be bad practice, as [noted here](https://github.com/dotnet/sdk/issues/833#issuecomment-354187744). I decided to set up the build of the library against .net standard 2.0 and the build of the console app against .net 4.6 and .net core 2.0, as this is what you mentioned in README (notice that .net 4.6 does not support .net standard 2.0 though, so the README is inaccurate - 4.6.1 is the first release, that oficially supports it; note the comments [on the limitations of that support](https://docs.microsoft.com/en-us/dotnet/standard/net-standard)).

For the library package this change seems minor, as _I would assume_ nobody calls the Main method when consuming the library. But if you take it exactly, it's a breaking change as it changes the public API. For the exe package this change is breaking as it changes which runtimes are required. I think one possibility would be to publish the changed library as 1.3.4 and leave the exe package as it is now.

I opened this PR as it solves the `Main` problem with quite minimal changes. I think there are more things which would be preferable to change regarding the build process. I will open another PR on that, which would make this PR obsolete when merging the other one.