### PR TITLE
Fix targeting, Add build nuget packages in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ script:
   - dotnet build -c Release Source/SharpAESCrypt.sln
   - dotnet test Unittest/Unittest.csproj --filter TestCategory=Bulk
   - dotnet test Unittest/Unittest.csproj --filter TestCategory!=Bulk
+  - dotnet pack -c Release .\SharpAESCrypt.csproj -p:IsLibrary=true
+  - dotnet pack -c Release .\SharpAESCrypt.csproj -p:IsLibrary=false

--- a/Source/SharpAESCrypt.cs
+++ b/Source/SharpAESCrypt.cs
@@ -1986,6 +1986,7 @@ namespace SharpAESCrypt
 
         #endregion
 
+#if !IsLibrary
         /// <summary>
         /// Main function, used when compiled as a standalone executable
         /// </summary>
@@ -2063,6 +2064,7 @@ namespace SharpAESCrypt
                 }
             }
         }
+#endif
     }
 
 }

--- a/Source/SharpAESCrypt.csproj
+++ b/Source/SharpAESCrypt.csproj
@@ -1,18 +1,42 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.3.3</Version>
-    <OutputType>Exe</OutputType>
+    <TargetFrameworks Condition="'$(IsLibrary)'!='true'">net452;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks Condition="'$(IsLibrary)'=='true'">netstandard2.0;net461</TargetFrameworks>
+    <Version>2.0.0</Version>
     <Copyright>LGPL 2018</Copyright>
     <Product>SharpAESCrypt</Product>
     <Company>SharpAESCrypt</Company>
     <PackageId>SharpAESCrypt</PackageId>
-    <ReleaseVersion>1.3.3</ReleaseVersion>
+    <ReleaseVersion>2.0.0</ReleaseVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DocumentationFile>bin\Release\$(TargetFramework)\SharpAESCrypt.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsLibrary)'!='true'">
+    <OutputType>Exe</OutputType>
+    <PackageId>SharpAESCrypt.exe</PackageId>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(IsLibrary)'=='true'">
+    <DefineConstants>IsLibrary</DefineConstants>
+    <OutputType>Library</OutputType>
+    <PackageId>SharpAESCrypt.dll</PackageId>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/kenkendk/sharpaescrypt/master/license.txt</PackageLicenseUrl>
+    <RepositoryUrl>https://github.com/kenkendk/sharpaescrypt</RepositoryUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageDescription>A C# implementation of the AESCrypt library</PackageDescription>
+    <Copyright>Copyright Kenneth Skovhede 2018</Copyright>
+    <Authors>Kenneth Skovhede</Authors>
+    <PackageTags>AES AESCrypt Crypto Encryption</PackageTags>
+    <PackageReleaseNotes>
+      Add multitargeting to compile a .Net Standard library without Main method and executables for .Net Core and Framework.
+    </PackageReleaseNotes>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
See #11 first. Merging this PR is a bigger change but I think it's preferable. I changed the version number to 2.0.0 as you could consider the changes breaking, but I'm sure that's a matter of opinion.

When merging this,
* the library does not contain the main method anymore (see #11)
* the library does target netstandard2.0 and net461 as [recommended by Microsoft](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting)
* the exe is not built against netstandard anymore, as this [seems to be a bad choice](https://github.com/dotnet/sdk/issues/833#issuecomment-354187744)
* the exe is built against net452 and netcore21, as these are the lowest versions which are currently [supported by Microsoft](https://support.microsoft.com/en-us/lifecycle/search/548) ([.Net Core Lifecycle](https://dotnet.microsoft.com/platform/support/policy/dotnet-core)). This will result in a "normal" exe and a dll which can be used cross platform with .net core.
* it's very easy to build the nuget packages in CI.

Travis seems to be suboptimal for compiling .Net Framework, so it might be worth considering moving to Azure Pipelines or AppVeyor. I'd be happy to help with this if needed.